### PR TITLE
PUS-27 Oppretter definisjonsfil for Jobbsøkerkompetanse.

### DIFF
--- a/uu-definisjon.js
+++ b/uu-definisjon.js
@@ -1,0 +1,14 @@
+exports.links = [
+    {
+        link: 'https://jobbsokerkompetanse-t6.nais.oera-q.local/jobbsokerkompetanse/',
+        options: {
+            browser: "firefox",
+            chain: [
+                { waitFor: '#root' },
+                { clickOn: '.knapp--hoved' },
+                { waitFor: '#sp-finn-spm-01' },
+                { clickOn: '.alternativer .alternativ > #finn-svar-0101 + label' }
+            ]
+        }
+    }
+];


### PR DESCRIPTION
Validatoren bruker definisjonsfilen til klikke seg forbi velkomssiden før den kjører UU-sjekken. Pga det selvsignerte sertifikate på NAV, kjører validatoren foreløpig testen på Firefox da Chrome i gjeldende versjon støtter ikke automatisering av usikre sertifikater. Støtte for dette kommer i Chrome 65 (på v. 63 p.d.d).