### PR TITLE
FO-10: alternativtype skala skal markeres hvis valgt

### DIFF
--- a/src/alternativ/alternativ.tsx
+++ b/src/alternativ/alternativ.tsx
@@ -58,10 +58,10 @@ function Alternativ({
         }
     }
 
-    function hentAlternativMarkering(){
-        return kanVelges?
-            (erValgt && sporsmalType === AlternativTyper.SKALA? 'markert' : '')
-            : 'disabled'
+    function hentAlternativMarkering() {
+        return kanVelges ?
+            (erValgt && sporsmalType === AlternativTyper.SKALA ? 'markert' : '')
+            : 'disabled';
     }
 
     return (

--- a/src/alternativ/alternativ.tsx
+++ b/src/alternativ/alternativ.tsx
@@ -58,6 +58,12 @@ function Alternativ({
         }
     }
 
+    function hentAlternativMarkering(){
+        return kanVelges?
+            (erValgt && sporsmalType === AlternativTyper.SKALA? 'markert' : '')
+            : 'disabled'
+    }
+
     return (
         <li key={alternativ.id} className={alternativKlasser}>
             <input
@@ -81,9 +87,7 @@ function Alternativ({
             />
             <label
                 htmlFor={alternativ.id}
-                className={`skjemaelement__label alternativ__label ${kanVelges
-                    ? ''
-                    : 'disabled'}`}
+                className={`skjemaelement__label alternativ__label ${hentAlternativMarkering()}`}
                 onClick={e => {
                     if (kanVelges) {
                         markerAlternativ();


### PR DESCRIPTION
Nå blir skala markert i blått på desktop, grønn ikon på mobil. På andre alternativtyper blir det ikke grønt ikon.